### PR TITLE
Require hyphens between param names and descs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 module.exports = {
+    'plugins': [
+        'jsdoc'
+    ]
     'rules': {
         'curly': [2, 'all'],
         'eqeqeq': 2,
@@ -100,6 +103,7 @@ module.exports = {
                 'return': 'returns'
             },
             'requireReturn': false
-        }]
+        }],
+        'jsdoc/require-hyphen-before-param-description': 1
     }
 };

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "devDependencies": {
     "gulp": "^3.9.1",
     "gulp-eslint": "^2.0.0"
+  },
+  "dependencies": {
+    "eslint-plugin-jsdoc": "^2.3.1"
   }
 }


### PR DESCRIPTION
Require that all @param JSDoc entries have a hyphen delimiting
the name of the parameter and the description for clarity.
In the event a hyphen is missing, throw a warning during linting.