### PR TITLE
Allow spaces in first lines of objects & arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,9 @@ module.exports = {
             'afterBlockComment': false,
             'beforeLineComment': false,
             'afterLineComment': false,
-            'allowBlockStart': true
+            'allowBlockStart': true,
+            'allowObjectStart': true,
+            'allowArrayStart': true
         }],
         'semi': [2, 'always'],
         'consistent-this': [2, 'self'],


### PR DESCRIPTION
In object & array literals, do not require a space
before comments on the first line. Subsequent properties
and values require a space prior to them.

So instead of requiring this:

    var foo = {

        // This is my property
        bar: 'baz'
    };
    var ownedRings = [

        /**
         * This is my own;
         * my precious.
         */
        "Isildur's Bane"
    ];

Instead we can do this:

    var foo = {
        // This is my property
        bar: 'baz'
    };
    var ownedRings = [
        /**
         * This is my own;
         * my precious.
         */
        "Isildur's Bane"
    ];