### PR TITLE
Add no-var and prefer-const rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,9 @@ module.exports = {
         'no-irregular-whitespace': 2,
         'no-undef': 2,
         'no-unused-vars': 2,
-        'prefer-const': 2,
+        'prefer-const': [2, {
+            'destructuring': 'all'
+        }],
         'no-var': 2,
         'linebreak-style': [2, 'unix'],
         'comma-style': [2, 'last'],

--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ module.exports = {
         'no-irregular-whitespace': 2,
         'no-undef': 2,
         'no-unused-vars': 2,
+        'prefer-const': 2,
+        'no-var': 2,
         'linebreak-style': [2, 'unix'],
         'comma-style': [2, 'last'],
         'dot-notation': 2,


### PR DESCRIPTION
This configuration will throw error upon usage of `var` to declare variables, helping to clarify the scope of a variable.

Also it will throw error when using `let` to declare variables that aren't reassigned post declaration, promoting the use of `const`.

Some interesting related articles:

- https://ponyfoo.com/articles/var-let-const
- https://medium.com/javascript-scene/javascript-es6-var-let-or-const-ba58b8dcde75