### PR TITLE
Add no-console and no-alert warning rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
         'no-undef': 2,
         'no-unused-vars': 2,
         'no-console': 1,
-        'no-alert': 1,
+        'no-alert': 2,
         'linebreak-style': [2, 'unix'],
         'comma-style': [2, 'last'],
         'dot-notation': 2,

--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ module.exports = {
         'no-irregular-whitespace': 2,
         'no-undef': 2,
         'no-unused-vars': 2,
+        'no-console': 1,
+        'no-alert': 1,
         'linebreak-style': [2, 'unix'],
         'comma-style': [2, 'last'],
         'dot-notation': 2,


### PR DESCRIPTION
This will promote usage of the debugger tools and avoid unwanted `console.log`'s in the code.

Whenever there is a good reason to use `console.log`, a comment should be added to the line/s affected.

i.e.
```javascript
// Provide simple feedback when the application finishes initialization
console.log('Server Started'); // eslint-disable-line no-console
```