### PR TITLE
Make eqeqeq rule smart

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = {
     ],
     'rules': {
         'curly': [2, 'all'],
-        'eqeqeq': 2,
+        'eqeqeq': [2, 'smart'],
         'wrap-iife': 2,
         'no-use-before-define': [2, {
             'functions': false


### PR DESCRIPTION
This makes the following usage legal:

```js
if (variable != null) {
  // def not null or undefined
}
```

This allows us to simplify something complex like this:

```js
if (variable !== undefined && variable !== null) {
  // def not null or undefined
}
```

This should be the only usage of the `!=`; `eqeqeq` will enforce
strict equality checking everywhere else.