### PR TITLE
Add space-before-function-paren rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,11 @@ module.exports = {
             'uninitialized': 'always',
             'initialized': 'never'
         }],
+        'space-before-function-paren': [2, {
+            'anonymous': 'never',
+            'named': 'never',
+            'asyncArrow': 'always'
+        }],
         'no-mixed-spaces-and-tabs': 2,
         'no-trailing-spaces': 2,
         'no-with': 2,


### PR DESCRIPTION
Requires no space between function keyword and opening parenthesis,
as well as named functions and opening parenthesis. _Forces_ a space
between the async keyword and the opening parenthesis
of an anonymous arrow function.

See https://eslint.org/docs/rules/space-before-function-paren.