### PR TITLE
Add spaced-line-comment rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,15 @@ module.exports = {
         'no-spaced-func': 2,
         'array-bracket-spacing': [2, 'never'],
         'space-in-parens': [2, 'never'],
+        'spaced-line-comment': [2, 'always', {
+            'exceptions': [
+                "-",
+                "+",
+                "=",
+                "/",
+                "*",
+            ],
+        }],
         'key-spacing': [2, {
             'beforeColon': false,
             'afterColon': true


### PR DESCRIPTION
This change forces single-line comments to always have a space between the comment operator and the content following it to increase legibility. Exceptions are made for comments that are meant to be horizontal rules (e.g. `//----------`).